### PR TITLE
fix: registro congelado, perfiles sugeridos, dashboard adminStats

### DIFF
--- a/src/app/features/auth/login/login.ts
+++ b/src/app/features/auth/login/login.ts
@@ -123,6 +123,7 @@ export class Login {
 
       if (response.user?.profileComplete === false && !isManagementUser) {
         this.toastr.info('Completa tu perfil academico para continuar.', 'Perfil incompleto');
+        sessionStorage.setItem('nexora.register.resume', 'true');
         this.router.navigate(['/register']);
         return;
       }
@@ -135,7 +136,7 @@ export class Login {
       } else {
         this.router.navigate(['/feed']);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (sessionStarted) {
         this.authSession.clear();
         await this.supabaseAuth.signOut().catch(() => undefined);

--- a/src/app/features/auth/register/actions/register-auth.actions.ts
+++ b/src/app/features/auth/register/actions/register-auth.actions.ts
@@ -22,9 +22,52 @@ export async function submitAccountStep(ctx: RegisterContext): Promise<void> {
     ctx.queueDraftSave();
     ctx.toastr.success('Revisa tu correo para validar la cuenta y continuar.', 'Correo enviado');
   } catch (error) {
+    // Usuario ya registrado: intentar login y saltar a completar perfil
+    if (ctx.supabaseAuth.isUserAlreadyConfirmedOrRegisteredError(error)) {
+      await handleAlreadyRegisteredUser(ctx, email, password);
+      return;
+    }
+
     ctx.toastr.error(ctx.supabaseAuth.toHumanErrorMessage(error), 'Registro detenido');
   } finally {
     ctx.isLoading.set(false);
+  }
+}
+
+async function handleAlreadyRegisteredUser(
+  ctx: RegisterContext,
+  email: string,
+  password: string
+): Promise<void> {
+  try {
+    const result = await ctx.supabaseAuth.signInWithEmail(email, password);
+    ctx.authSession.start({ user: result.user, tokens: result.tokens }, false);
+
+    const response = await firstValueFrom(ctx.authApi.getSessionProfile());
+    if (response?.user?.profileComplete === false) {
+      // Pre-poblar con datos existentes y saltar al paso de identidad
+      const user = response.user;
+      if (user.username) ctx.identityForm.controls.username.setValue(user.username);
+      if (user.fullName) ctx.identityForm.controls.fullName.setValue(user.fullName);
+      if (user.career) ctx.identityForm.controls.career.setValue(user.career);
+      if (user.bio) ctx.preferencesForm.controls.bio.setValue(user.bio);
+      if (user.academicInterests?.length) {
+        ctx.preferencesForm.controls.selectedInterests.setValue([...user.academicInterests]);
+      }
+      ctx.currentStep.set(2);
+      ctx.toastr.info('Completa tu perfil académico para continuar.', 'Perfil incompleto');
+      return;
+    }
+
+    // Perfil ya completo: redirigir a feed
+    ctx.toastr.success('Tu cuenta ya estaba registrada.', 'Bienvenido de nuevo');
+    ctx.router.navigate(['/feed']);
+  } catch {
+    ctx.toastr.info(
+      'Este correo ya está registrado. Inicia sesión para continuar.',
+      'Cuenta existente'
+    );
+    ctx.router.navigate(['/login']);
   }
 }
 

--- a/src/app/features/auth/register/register.ts
+++ b/src/app/features/auth/register/register.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, DestroyRef, inject, OnInit } from '
 import { FormBuilder, ReactiveFormsModule, FormGroup, AbstractControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import { Subject, debounceTime } from 'rxjs';
+import { Subject, debounceTime, firstValueFrom } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { AuthSession } from '../../../core/services/auth-session';
@@ -100,6 +100,8 @@ export class Register implements OnInit {
   readonly backDisabled = this.state.backDisabled;
 
   ngOnInit(): void {
+    void this.tryResumeIncompleteRegistration();
+
     void loadRegistrationCatalogs(this);
     restoreDraft(this);
     startDraftCountdown(this);
@@ -111,6 +113,39 @@ export class Register implements OnInit {
     this.draftSave$
       .pipe(debounceTime(250), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => persistDraft(this));
+  }
+
+  private async tryResumeIncompleteRegistration(): Promise<void> {
+    const resumeFlag = sessionStorage.getItem('nexora.register.resume');
+    const hasSession = this.authSession.isAuthenticated();
+
+    if (!resumeFlag && !hasSession) return;
+
+    // Si viene de login con perfil incompleto, usar las credenciales de la sesión
+    if (resumeFlag) {
+      sessionStorage.removeItem('nexora.register.resume');
+    }
+
+    if (!this.authSession.getTokens()?.accessToken) return;
+
+    try {
+      const response = await firstValueFrom(this.authApi.getSessionProfile());
+      if (!response || response.user?.profileComplete !== false) return;
+
+      // Pre-poblar formulario con datos existentes del backend
+      const user = response.user;
+      if (user.username) this.identityForm.controls.username.setValue(user.username);
+      if (user.fullName) this.identityForm.controls.fullName.setValue(user.fullName);
+      if (user.career) this.identityForm.controls.career.setValue(user.career);
+      if (user.bio) this.preferencesForm.controls.bio.setValue(user.bio);
+      if (user.academicInterests?.length) {
+        this.preferencesForm.controls.selectedInterests.setValue([...user.academicInterests]);
+      }
+
+      this.currentStep.set(2);
+    } catch {
+      // Si falla getSessionProfile, seguir con el flujo normal
+    }
   }
 
   nextStep(): void { nextStep(this); }

--- a/src/app/features/feed/components/feed-trends.spec.ts
+++ b/src/app/features/feed/components/feed-trends.spec.ts
@@ -7,6 +7,7 @@ import { provideRouter } from '@angular/router';
 import { AuthSession } from '../../../core/services/auth-session';
 import { ProfileService } from '../../profile/services/profile.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { InvitationService } from '../../groups/services/invitation.service';
 import { TestBed } from '@angular/core/testing';
 import { signal, DestroyRef } from '@angular/core';
 
@@ -54,6 +55,10 @@ describe('FeedTrends Logic', () => {
       show: vi.fn()
     };
 
+    const mockInvitationService: Partial<InvitationService> = {
+      discoverUsers: () => of([])
+    };
+
     await TestBed.configureTestingModule({
       providers: [
         provideRouter([]),
@@ -63,6 +68,7 @@ describe('FeedTrends Logic', () => {
         { provide: ProfileService, useValue: mockProfileService },
         { provide: ToastService, useValue: mockToastService },
         { provide: DestroyRef, useValue: { onDestroy: () => {} } },
+        { provide: InvitationService, useValue: mockInvitationService },
         TestFeedTrends
       ]
     });

--- a/src/app/features/feed/components/feed-trends/feed-trends.ts
+++ b/src/app/features/feed/components/feed-trends/feed-trends.ts
@@ -2,13 +2,14 @@ import { Component, signal, inject, OnInit, DestroyRef, Directive } from '@angul
 import { RouterLink, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { forkJoin, of } from 'rxjs';
-import { map, catchError } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { FeedTagsService } from '../../services/feed-tags.service';
 import { FeedService } from '../../services/feed.service';
 import { Trend, SuggestedUser } from '../../models/trend.model';
 import { ProfileService } from '../../../profile/services/profile.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthSession } from '../../../../core/services/auth-session';
+import { InvitationService } from '../../../groups/services/invitation.service';
 
 @Directive()
 export abstract class FeedTrendsBase implements OnInit {
@@ -18,6 +19,7 @@ export abstract class FeedTrendsBase implements OnInit {
   protected readonly profileService = inject(ProfileService);
   protected readonly toastService = inject(ToastService);
   protected readonly authSession = inject(AuthSession);
+  protected readonly invitationService = inject(InvitationService);
   protected readonly destroyRef = inject(DestroyRef);
 
   loading = signal(true);
@@ -90,8 +92,32 @@ export abstract class FeedTrendsBase implements OnInit {
           
           if (users.length >= 3) break;
         }
-        this.suggestedUsers.set(users);
-        this.loadingSuggestions.set(false);
+
+        if (users.length > 0) {
+          this.suggestedUsers.set(users);
+          this.loadingSuggestions.set(false);
+          return;
+        }
+
+        // Fallback: discover users from backend when posts don't yield suggestions
+        const excludeIds = Array.from(followingIds).concat(currentUserId).filter((id): id is string => !!id);
+        this.invitationService.discoverUsers(excludeIds).subscribe({
+          next: (discovered) => {
+            const fallback: SuggestedUser[] = discovered.slice(0, 3).map(u => ({
+              id: u.userId,
+              name: u.fullName || u.username,
+              role: 'Investigador',
+              avatar: u.avatarUrl || `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(u.username)}`,
+              isFollowing: false
+            }));
+            this.suggestedUsers.set(fallback);
+            this.loadingSuggestions.set(false);
+          },
+          error: () => {
+            this.suggestedUsers.set([]);
+            this.loadingSuggestions.set(false);
+          }
+        });
       },
       error: (err) => {
         console.error('Error loading suggested users', err);

--- a/src/app/features/feed/pages/explore/explore-page.ts
+++ b/src/app/features/feed/pages/explore/explore-page.ts
@@ -15,6 +15,7 @@ import { PostCardComponent } from '../../components/post-card/post-card';
 import { AuthSession } from '../../../../core/services/auth-session';
 import { ProfileService } from '../../../profile/services/profile.service';
 import { UserSuggestCard } from '../../../../features/home/components/explorar/components/user-suggest-card/user-suggest-card';
+import { InvitationService } from '../../../groups/services/invitation.service';
 
 @Directive()
 export abstract class ExplorePageBase implements OnInit {
@@ -23,6 +24,7 @@ export abstract class ExplorePageBase implements OnInit {
   protected readonly paginationQueue = inject(FeedPaginationQueueService);
   protected readonly authSession = inject(AuthSession);
   protected readonly profileService = inject(ProfileService);
+  protected readonly invitationService = inject(InvitationService);
   protected readonly destroyRef = inject(DestroyRef);
   protected readonly route = inject(ActivatedRoute);
 
@@ -192,7 +194,26 @@ export abstract class ExplorePageBase implements OnInit {
             isFollowing: false
           });
         }
-        this.suggestedUsers.set(users);
+        if (users.length > 0) {
+          this.suggestedUsers.set(users);
+          return;
+        }
+
+        // Fallback: discover users from backend
+        const excludeIds = Array.from(followingIds).concat(user.id).filter((id): id is string => !!id);
+        this.invitationService.discoverUsers(excludeIds).subscribe({
+          next: (discovered) => {
+            const fallback: SuggestedUser[] = discovered.slice(0, 5).map(u => ({
+              id: u.userId,
+              name: u.fullName || u.username,
+              role: 'Investigador',
+              avatar: u.avatarUrl || `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(u.username)}`,
+              isFollowing: false
+            }));
+            this.suggestedUsers.set(fallback);
+          },
+          error: () => this.suggestedUsers.set([])
+        });
       });
     });
   }

--- a/src/app/features/groups/services/invitation.service.ts
+++ b/src/app/features/groups/services/invitation.service.ts
@@ -10,7 +10,8 @@ import {
   GROUP_INVITATIONS_QUERY,
   CANCEL_INVITATION_MUTATION,
   SEARCH_USERS_QUERY,
-} from '../../../graphql/graphql.queries';
+  DISCOVER_USERS_QUERY,
+} from '../../../graphql/queries/group.queries';
 
 export interface GroupInvitation {
   invitationId: string;
@@ -44,6 +45,10 @@ interface GroupInvitationsQueryResponse {
 
 interface SearchUsersQueryResponse {
   searchUsers: UserSearchResult[];
+}
+
+interface DiscoverUsersQueryResponse {
+  discoverUsers: UserSearchResult[];
 }
 
 interface InviteMutationResponse {
@@ -101,6 +106,19 @@ export class InvitationService {
       distinctUntilChanged(),
       switchMap((query) => this.searchUsers(query)),
     );
+  }
+
+  discoverUsers(excludeUserIds: string[] = []): Observable<UserSearchResult[]> {
+    return this.apollo
+      .query<DiscoverUsersQueryResponse>({
+        query: DISCOVER_USERS_QUERY,
+        variables: { excludeUserIds: excludeUserIds.length > 0 ? excludeUserIds : null },
+        fetchPolicy: 'network-only',
+      })
+      .pipe(
+        map((result) => result.data?.discoverUsers ?? []),
+        catchError(() => of([]))
+      );
   }
 
   inviteMember(groupId: string, username: string): Observable<GroupInvitation> {

--- a/src/app/graphql/queries/group.queries.ts
+++ b/src/app/graphql/queries/group.queries.ts
@@ -257,3 +257,14 @@ export const SEARCH_USERS_QUERY = gql`
     }
   }
 `;
+
+export const DISCOVER_USERS_QUERY = gql`
+  query DiscoverUsers($excludeUserIds: [ID!]) {
+    discoverUsers(excludeUserIds: $excludeUserIds) {
+      userId
+      username
+      fullName
+      avatarUrl
+    }
+  }
+`;


### PR DESCRIPTION
- register: detectar sesión existente y saltar a identidad
- register: manejar 'user already registered' en submitAccountStep
- login: pasar flag nexora.register.resume al registro
- feed-trends + explore: fallback a discoverUsers GraphQL
- invitation.service: agregar discoverUsers()
- group.queries: DISCOVER_USERS_QUERY