### PR TITLE
feat(management): dashboard PDF report, promote modal improvements, s…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "apollo-angular": "^13.0.0",
         "chart.js": "^4.5.1",
         "graphql": "^16",
+        "jspdf": "^4.2.1",
         "ng2-charts": "^10.0.0",
         "ngx-tiptap": "^14.0.1",
         "ngx-toastr": "^20.0.5",
@@ -1191,6 +1192,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5645,6 +5655,26 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6759,6 +6789,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
@@ -6996,6 +7036,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -7258,6 +7318,18 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -7289,6 +7361,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -7469,6 +7551,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8106,6 +8198,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8150,6 +8253,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -8523,6 +8632,20 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -8694,6 +8817,12 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -8987,6 +9116,23 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -10427,6 +10573,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -10573,6 +10735,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10931,6 +11100,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10977,6 +11156,13 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -11032,6 +11218,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.4",
@@ -11586,6 +11782,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11662,6 +11868,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -11674,7 +11890,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -11715,6 +11932,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinybench": {
@@ -12163,6 +12390,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "apollo-angular": "^13.0.0",
     "chart.js": "^4.5.1",
     "graphql": "^16",
+    "jspdf": "^4.2.1",
     "ng2-charts": "^10.0.0",
     "ngx-tiptap": "^14.0.1",
     "ngx-toastr": "^20.0.5",

--- a/src/app/features/management/graphql/management.queries.ts
+++ b/src/app/features/management/graphql/management.queries.ts
@@ -191,3 +191,15 @@ export const DELETE_EVENT_MUTATION = `
     eliminarEvento(eventId: $id)
   }
 `;
+
+export const PROMOTE_USER_MUTATION = `
+  mutation PromoteUser($userId: ID!, $role: UserRole!) {
+    promoteUser(userId: $userId, role: $role) {
+      id
+      username
+      fullName
+      career
+      email
+    }
+  }
+`;

--- a/src/app/features/management/management.html
+++ b/src/app/features/management/management.html
@@ -38,10 +38,10 @@
     </nav>
     
     <div class="sidebar-footer">
-      <a routerLink="/" class="back-link" (click)="closeSidebar()">
-        <span class="material-symbols-outlined">arrow_back</span>
-        Volver al Sitio
-      </a>
+      <button type="button" class="back-link" (click)="signOut()">
+        <span class="material-symbols-outlined">logout</span>
+        Cerrar Sesión
+      </button>
     </div>
   </aside>
   

--- a/src/app/features/management/management.ts
+++ b/src/app/features/management/management.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { filter } from 'rxjs';
 import { PermissionService } from '../../core/services/permission.service';
+import { SupabaseAuthService } from '../../core/services/supabase-auth.service';
 
 @Component({
   selector: 'app-management',
@@ -14,6 +15,7 @@ import { PermissionService } from '../../core/services/permission.service';
 export class ManagementPage {
   readonly permissionService = inject(PermissionService);
   private readonly router = inject(Router);
+  private readonly authService = inject(SupabaseAuthService);
 
   readonly isSidebarOpen = signal(false);
   readonly currentPath = signal(this.router.url);
@@ -51,5 +53,10 @@ export class ManagementPage {
 
   closeSidebar(): void {
     this.isSidebarOpen.set(false);
+  }
+
+  async signOut(): Promise<void> {
+    await this.authService.signOut();
+    this.router.navigate(['/login']);
   }
 }

--- a/src/app/features/management/pages/dashboard/dashboard.css
+++ b/src/app/features/management/pages/dashboard/dashboard.css
@@ -145,3 +145,26 @@
 canvas {
   filter: drop-shadow(0 0 10px rgba(227, 38, 46, 0.05));
 }
+
+/* Modal Overlay */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: var(--brand-surface);
+  border: 1px solid var(--brand-border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+}

--- a/src/app/features/management/pages/dashboard/dashboard.html
+++ b/src/app/features/management/pages/dashboard/dashboard.html
@@ -1,130 +1,228 @@
-@if (loading()) {
-  <div class="flex flex-col items-center justify-center py-20">
-    <div class="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-brand-red mb-4"></div>
-    <p class="text-brand-muted animate-pulse font-bold tracking-widest text-xs uppercase">Sincronizando NEXORA Hub...</p>
-  </div>
-} @else if (stats(); as s) {
-  <!-- KPI Row -->
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-    <div class="stat-card group">
-      <div class="flex justify-between items-start mb-4">
-        <span class="material-symbols-outlined text-brand-red p-2 bg-brand-red/10 rounded-lg">group</span>
-        <span class="text-xs font-bold text-green-500 bg-green-500/10 px-2 py-1 rounded">+12%</span>
-      </div>
-      <h3>Total Usuarios</h3>
-      <p class="stat-value">{{ s.totalUsers }}</p>
-      <div class="h-16 mt-4">
-        <canvas baseChart [data]="lineChartData()" [options]="lineChartOptions" [type]="'line'"></canvas>
-      </div>
+<div class="flex min-h-screen flex-col bg-brand-bg">
+  @if (loading()) {
+    <div class="flex flex-col items-center justify-center py-20">
+      <div class="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-brand-red mb-4"></div>
+      <p class="text-brand-muted animate-pulse font-bold tracking-widest text-xs uppercase">Sincronizando NEXORA Hub...</p>
     </div>
-
-    <div class="stat-card">
-      <div class="flex justify-between items-start mb-4">
-        <span class="material-symbols-outlined text-blue-500 p-2 bg-blue-500/10 rounded-lg">article</span>
-        <span class="text-xs font-bold text-blue-500 bg-blue-500/10 px-2 py-1 rounded">Activos</span>
-      </div>
-      <h3>Publicaciones</h3>
-      <p class="stat-value">{{ s.totalPosts }}</p>
-      <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Promedio: 1.2 p/día</p>
-    </div>
-
-    <div class="stat-card">
-      <div class="flex justify-between items-start mb-4">
-        <span class="material-symbols-outlined text-purple-500 p-2 bg-purple-500/10 rounded-lg">event</span>
-        <span class="text-xs font-bold text-brand-muted bg-white/5 px-2 py-1 rounded">Estable</span>
-      </div>
-      <h3>Eventos</h3>
-      <p class="stat-value">{{ s.activeEvents }}</p>
-      <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Próximo: Mañana 10:00</p>
-    </div>
-
-    <div class="stat-card highlight">
-      <div class="flex justify-between items-start mb-4">
-        <span class="material-symbols-outlined text-brand-red p-2 bg-brand-red/20 rounded-lg animate-pulse">sensors</span>
-        <div class="flex gap-1">
-          <span class="h-2 w-2 rounded-full bg-green-500"></span>
-          <span class="h-2 w-2 rounded-full bg-green-500"></span>
+  } @else if (stats(); as s) {
+    <!-- KPI Row -->
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8 px-4 md:px-8 lg:px-14 mt-6">
+      <div class="stat-card group">
+        <div class="flex justify-between items-start mb-4">
+          <span class="material-symbols-outlined text-brand-red p-2 bg-brand-red/10 rounded-lg">group</span>
+          <span class="text-xs font-bold text-green-500 bg-green-500/10 px-2 py-1 rounded">+12%</span>
         </div>
-      </div>
-      <h3>Estado Sistema</h3>
-      <p class="text-xl font-black text-white mt-2">OPERATIVO</p>
-      <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Latencia: 24ms</p>
-    </div>
-  </div>
-
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-    <!-- Charts & Distribution -->
-    <div class="lg:col-span-2 space-y-8">
-      <div class="bg-surface-2 border border-border rounded-2xl p-6">
-        <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
-          <span class="material-symbols-outlined text-brand-red">analytics</span>
-          Distribución de Contenido
-        </h3>
-        <div class="h-64">
-          <canvas baseChart [data]="pieChartData()" [options]="pieChartOptions" [type]="'doughnut'"></canvas>
+        <h3>Total Usuarios</h3>
+        <p class="stat-value">{{ s.totalUsers }}</p>
+        <div class="h-16 mt-4">
+          <canvas baseChart [data]="lineChartData()" [options]="lineChartOptions" [type]="'line'"></canvas>
         </div>
       </div>
 
-      <div class="bg-surface-2 border border-border rounded-2xl p-6">
-        <h3 class="text-lg font-bold mb-6">Acciones Rápidas</h3>
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <button class="quick-action">
-            <span class="material-symbols-outlined">person_add</span>
-            <span>Nuevo Admin</span>
-          </button>
-          <button class="quick-action">
-            <span class="material-symbols-outlined">campaign</span>
-            <span>Anuncio</span>
-          </button>
-          <button class="quick-action">
-            <span class="material-symbols-outlined">download</span>
-            <span>Reporte</span>
-          </button>
-          <button class="quick-action">
-            <span class="material-symbols-outlined">settings</span>
-            <span>Ajustes</span>
-          </button>
+      <div class="stat-card">
+        <div class="flex justify-between items-start mb-4">
+          <span class="material-symbols-outlined text-blue-500 p-2 bg-blue-500/10 rounded-lg">article</span>
+          <span class="text-xs font-bold text-blue-500 bg-blue-500/10 px-2 py-1 rounded">Activos</span>
         </div>
+        <h3>Publicaciones</h3>
+        <p class="stat-value">{{ s.totalPosts }}</p>
+        <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Promedio: 1.2 p/día</p>
+      </div>
+
+      <div class="stat-card">
+        <div class="flex justify-between items-start mb-4">
+          <span class="material-symbols-outlined text-purple-500 p-2 bg-purple-500/10 rounded-lg">event</span>
+          <span class="text-xs font-bold text-brand-muted bg-white/5 px-2 py-1 rounded">Estable</span>
+        </div>
+        <h3>Eventos</h3>
+        <p class="stat-value">{{ s.activeEvents }}</p>
+        <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Próximo: Mañana 10:00</p>
+      </div>
+
+      <div class="stat-card highlight">
+        <div class="flex justify-between items-start mb-4">
+          <span class="material-symbols-outlined text-brand-red p-2 bg-brand-red/20 rounded-lg animate-pulse">sensors</span>
+          <div class="flex gap-1">
+            <span class="h-2 w-2 rounded-full bg-green-500"></span>
+            <span class="h-2 w-2 rounded-full bg-green-500"></span>
+          </div>
+        </div>
+        <h3>Estado Sistema</h3>
+        <p class="text-xl font-black text-white mt-2">OPERATIVO</p>
+        <p class="text-[10px] text-brand-muted mt-4 uppercase font-bold tracking-tighter">Latencia: 24ms</p>
       </div>
     </div>
 
-    <!-- Recent Activity Side -->
-    <div class="lg:col-span-1">
-      <div class="bg-surface-2 border border-border rounded-2xl h-full flex flex-col">
-        <div class="p-6 border-b border-border flex justify-between items-center">
-          <h3 class="font-bold flex items-center gap-2">
-            <span class="material-symbols-outlined text-brand-red">history</span>
-            Actividad
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 px-4 md:px-8 lg:px-14 mb-8">
+      <!-- Charts & Actions -->
+      <div class="lg:col-span-2 space-y-8">
+        <div class="bg-surface-2 border border-border rounded-2xl p-6">
+          <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
+            <span class="material-symbols-outlined text-brand-red">analytics</span>
+            Distribución de Contenido
           </h3>
-          <button class="text-xs text-brand-red font-bold hover:underline">Ver Todo</button>
+          <div class="h-64">
+            <canvas baseChart [data]="pieChartData()" [options]="pieChartOptions" [type]="'doughnut'"></canvas>
+          </div>
         </div>
-        <div class="flex-1 overflow-y-auto p-4 space-y-4">
-          @for (activity of s.recentActivity; track activity.id) {
-            <div class="activity-card">
-              <div class="activity-indicator"></div>
-              <div class="flex-1">
-                <div class="flex justify-between items-start">
-                  <span class="text-[10px] font-black text-brand-red uppercase tracking-widest">{{ activity.type }}</span>
-                  <span class="text-[10px] text-brand-muted">{{ activity.createdAt | date:'short' }}</span>
+
+        <div class="bg-surface-2 border border-border rounded-2xl p-6">
+          <h3 class="text-lg font-bold mb-6">Acciones Rápidas</h3>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <button class="quick-action" (click)="openPromoteModal()">
+              <span class="material-symbols-outlined">person_add</span>
+              <span>Nuevo Admin</span>
+            </button>
+            <button class="quick-action" (click)="downloadReport()">
+              <span class="material-symbols-outlined">download</span>
+              <span>Reporte</span>
+            </button>
+            <button class="quick-action">
+              <span class="material-symbols-outlined">settings</span>
+              <span>Ajustes</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recent Activity -->
+      <div class="lg:col-span-1">
+        <div class="bg-surface-2 border border-border rounded-2xl h-full flex flex-col">
+          <div class="p-6 border-b border-border flex justify-between items-center">
+            <h3 class="font-bold flex items-center gap-2">
+              <span class="material-symbols-outlined text-brand-red">history</span>
+              Actividad
+            </h3>
+            <button class="text-xs text-brand-red font-bold hover:underline">Ver Todo</button>
+          </div>
+          <div class="flex-1 overflow-y-auto p-4 space-y-4">
+            @for (activity of s.recentActivity; track activity.id) {
+              <div class="activity-card">
+                <div class="activity-indicator"></div>
+                <div class="flex-1">
+                  <div class="flex justify-between items-start">
+                    <span class="text-[10px] font-black text-brand-red uppercase tracking-widest">{{ activity.type }}</span>
+                    <span class="text-[10px] text-brand-muted">{{ activity.createdAt | date:'short' }}</span>
+                  </div>
+                  <p class="text-sm text-brand-text mt-1 leading-tight">{{ activity.description }}</p>
                 </div>
-                <p class="text-sm text-brand-text mt-1 leading-tight">{{ activity.description }}</p>
               </div>
-            </div>
-          } @empty {
-            <div class="text-center py-10 opacity-30">
-              <span class="material-symbols-outlined text-4xl">inbox</span>
-              <p class="text-xs mt-2">Sin actividad reciente</p>
+            } @empty {
+              <div class="text-center py-10 opacity-30">
+                <span class="material-symbols-outlined text-4xl">inbox</span>
+                <p class="text-xs mt-2">Sin actividad reciente</p>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+  } @else {
+    <div class="bg-brand-red/10 border border-brand-red/20 rounded-2xl p-12 text-center mx-4 md:mx-8 lg:mx-14 my-6">
+      <span class="material-symbols-outlined text-brand-red text-5xl mb-4">cloud_off</span>
+      <h3 class="text-xl font-bold text-white mb-2">Error de Sincronización</h3>
+      <p class="text-brand-muted max-w-xs mx-auto text-sm">No se pudieron recuperar las métricas del NEXORA Hub. Verifica tu conexión con el núcleo central.</p>
+      <button (click)="ngOnInit()" class="mt-6 px-6 py-2 bg-brand-red text-white rounded-full font-bold text-sm">Reintentar</button>
+    </div>
+  }
+</div>
+
+<!-- Promote User Modal -->
+@if (showPromoteModal()) {
+  <div class="modal-overlay" (click)="closePromoteModal()">
+    <div class="modal-content" (click)="$event.stopPropagation()">
+      <div class="flex justify-between items-center mb-6">
+        <h2 class="text-xl font-bold">Promover Usuario</h2>
+        <button class="text-brand-muted hover:text-white" (click)="closePromoteModal()">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+      </div>
+
+      <!-- Search -->
+      <div class="mb-4">
+        <input
+          type="text"
+          class="w-full bg-surface-1 border border-border rounded-xl px-4 py-3 text-sm text-brand-text placeholder-brand-muted focus:outline-none focus:border-brand-red"
+          placeholder="Buscar por nombre o username..."
+          [ngModel]="promoteSearch()"
+          (ngModelChange)="promoteSearch.set($event); searchPromoteUsers()"
+        />
+      </div>
+
+      <!-- Results -->
+      @if (promoteSearching()) {
+        <div class="flex justify-center py-6">
+          <div class="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-brand-red"></div>
+        </div>
+      } @else if (promoteResults().length > 0) {
+        <div class="mb-4 max-h-48 overflow-y-auto space-y-2">
+          @for (user of promoteResults(); track user.id) {
+            <div
+              class="flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-all border border-transparent hover:border-border"
+              [style.border-color]="selectedUser()?.id === user.id ? 'var(--brand-red)' : 'transparent'"
+              [style.background-color]="selectedUser()?.id === user.id ? 'rgba(227,38,46,0.15)' : 'transparent'"
+              (click)="selectUserForPromote(user)"
+            >
+              <img
+                [src]="user.avatarUrl || 'https://api.dicebear.com/7.x/avataaars/svg?seed=' + user.username"
+                [alt]="user.fullName || user.username || 'Usuario'"
+                class="h-10 w-10 rounded-full object-cover bg-surface-1"
+              />
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-brand-text truncate">
+                  {{ user.fullName || user.username || 'Sin nombre' }}
+                </p>
+                <p class="text-xs text-brand-muted truncate">{{ user.email }}</p>
+              </div>
+              @if (selectedUser()?.id === user.id) {
+                <span class="material-symbols-outlined text-brand-red text-lg">check_circle</span>
+              }
             </div>
           }
         </div>
-      </div>
+        @if (promoteResults().length === 5) {
+          <p class="text-[10px] text-brand-muted text-center">Mostrando los primeros 5 resultados</p>
+        }
+      } @else if (promoteSearch().length >= 2) {
+        <div class="text-center py-6">
+          <span class="material-symbols-outlined text-brand-muted text-3xl">search_off</span>
+          <p class="text-sm text-brand-muted mt-2">Sin resultados para "{{ promoteSearch() }}"</p>
+        </div>
+      }
+
+      <!-- Role selector -->
+      @if (selectedUser()) {
+        <div class="mb-6">
+          <label class="block text-xs font-bold text-brand-muted uppercase tracking-wider mb-2">Nuevo Rol</label>
+          <div class="grid grid-cols-3 gap-2">
+            @for (role of roles; track role.value) {
+              <button
+                class="px-3 py-2 rounded-lg text-xs font-semibold border transition-all"
+                [style.background-color]="selectedRole() === role.value ? 'var(--brand-red)' : 'transparent'"
+                [style.border-color]="selectedRole() === role.value ? 'var(--brand-red)' : 'var(--border)'"
+                [style.color]="selectedRole() === role.value ? 'white' : 'var(--brand-text)'"
+                (click)="selectedRole.set(role.value)"
+              >
+                {{ role.label }}
+              </button>
+            }
+          </div>
+        </div>
+
+        <!-- Confirm -->
+        <button
+          class="w-full py-3 rounded-xl font-bold text-sm text-white transition-all"
+          style="background-color: var(--brand-red)"
+          [disabled]="promoteLoading()"
+          (click)="confirmPromote()"
+        >
+          @if (promoteLoading()) {
+            <span class="animate-pulse">Procesando...</span>
+          } @else {
+            Asignar Rol
+          }
+        </button>
+      }
     </div>
-  </div>
-} @else {
-  <div class="bg-brand-red/10 border border-brand-red/20 rounded-2xl p-12 text-center">
-    <span class="material-symbols-outlined text-brand-red text-5xl mb-4">cloud_off</span>
-    <h3 class="text-xl font-bold text-white mb-2">Error de Sincronización</h3>
-    <p class="text-brand-muted max-w-xs mx-auto text-sm">No se pudieron recuperar las métricas del NEXORA Hub. Verifica tu conexión con el núcleo central.</p>
-    <button (click)="ngOnInit()" class="mt-6 px-6 py-2 bg-brand-red text-white rounded-full font-bold text-sm">Reintentar</button>
   </div>
 }

--- a/src/app/features/management/pages/dashboard/dashboard.ts
+++ b/src/app/features/management/pages/dashboard/dashboard.ts
@@ -1,23 +1,212 @@
-import { Component, OnInit, inject, computed, effect } from '@angular/core';
+import { Component, OnInit, inject, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { jsPDF } from 'jspdf';
 import { ManagementService } from '../../services/management.service';
 import { BaseChartDirective } from 'ng2-charts';
 import { Chart, ChartConfiguration, ChartOptions, registerables } from 'chart.js';
+import { UserProfile } from '../../models/admin-dashboard.model';
 
 Chart.register(...registerables);
 
 @Component({
   selector: 'app-dashboard-view',
   standalone: true,
-  imports: [CommonModule, BaseChartDirective],
+  imports: [CommonModule, FormsModule, BaseChartDirective],
   templateUrl: './dashboard.html',
   styleUrls: ['./dashboard.css'],
 })
 export class DashboardView implements OnInit {
   private readonly managementService = inject(ManagementService);
-  
+
   readonly stats = this.managementService.stats;
   readonly loading = this.managementService.loading;
+
+  // Promote modal state
+  showPromoteModal = signal(false);
+  promoteSearch = signal('');
+  selectedUser = signal<UserProfile | null>(null);
+  selectedRole = signal<string>('ROLE_ADMIN');
+  promoteLoading = signal(false);
+  promoteSearching = signal(false);
+
+  readonly roles = [
+    { value: 'ROLE_ADMIN', label: 'Administrador' },
+    { value: 'ROLE_OFFICIAL', label: 'Cuenta Oficial' },
+    { value: 'ROLE_STUDENT', label: 'Estudiante' },
+  ];
+
+  // Results derived from users signal + current search
+  readonly promoteResults = computed(() => {
+    const q = this.promoteSearch().toLowerCase();
+    return this.managementService.users()
+      .filter(u =>
+        !q ||
+        u.username?.toLowerCase().includes(q) ||
+        u.fullName?.toLowerCase().includes(q) ||
+        u.email?.toLowerCase().includes(q)
+      )
+      .slice(0, 5);
+  });
+
+  openPromoteModal(): void {
+    this.managementService.resetUsers();
+    this.showPromoteModal.set(true);
+    this.promoteSearch.set('');
+    this.selectedUser.set(null);
+    this.selectedRole.set('ROLE_ADMIN');
+  }
+
+  closePromoteModal(): void {
+    this.showPromoteModal.set(false);
+  }
+
+  searchPromoteUsers(): void {
+    const q = this.promoteSearch();
+    if (q.length < 2) { return; }
+    this.promoteSearching.set(true);
+    this.managementService.loadUsers(10, 0, false, q).subscribe({
+      complete: () => this.promoteSearching.set(false),
+      error: () => this.promoteSearching.set(false),
+    });
+  }
+
+  selectUserForPromote(user: UserProfile): void {
+    this.selectedUser.set(user);
+  }
+
+  confirmPromote(): void {
+    const user = this.selectedUser();
+    if (!user) return;
+    this.promoteLoading.set(true);
+    this.managementService.promoteUser(user.id, this.selectedRole()).subscribe({
+      next: () => {
+        this.promoteLoading.set(false);
+        this.closePromoteModal();
+      },
+      error: () => this.promoteLoading.set(false),
+    });
+  }
+
+  downloadReport(): void {
+    const s = this.stats();
+    const doc = new jsPDF();
+
+    // Header
+    doc.setFillColor(26, 26, 26);
+    doc.rect(0, 0, 210, 40, 'F');
+    doc.setTextColor(227, 38, 46);
+    doc.setFontSize(22);
+    doc.setFont('helvetica', 'bold');
+    doc.text('NEXORA', 20, 20);
+    doc.setFontSize(10);
+    doc.setTextColor(200, 200, 200);
+    doc.setFont('helvetica', 'normal');
+    doc.text('Reporte de Estadisticas - Dashboard', 20, 30);
+    doc.setFontSize(8);
+    doc.text(`Generado: ${new Date().toLocaleString('es-PE')}`, 20, 37);
+
+    // KPIs
+    let y = 55;
+    doc.setTextColor(26, 26, 26);
+    doc.setFontSize(14);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Resumen General', 20, y);
+    y += 8;
+
+    doc.setFontSize(36);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(227, 38, 46);
+    doc.text(String(s?.totalUsers ?? 0), 20, y + 12);
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(100, 100, 100);
+    doc.text('Total Usuarios', 20, y + 20);
+
+    doc.setFontSize(36);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(26, 26, 26);
+    doc.text(String(s?.totalPosts ?? 0), 70, y + 12);
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(100, 100, 100);
+    doc.text('Publicaciones', 70, y + 20);
+
+    doc.setFontSize(36);
+    doc.setFont('helvetica', 'bold');
+    doc.text(String(s?.activeEvents ?? 0), 120, y + 12);
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(100, 100, 100);
+    doc.text('Eventos Activos', 120, y + 20);
+
+    y += 35;
+
+    // Crecimiento
+    doc.setFontSize(14);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(26, 26, 26);
+    doc.text('Crecimiento de Usuarios', 20, y);
+    y += 8;
+
+    const growth = s?.userGrowth ?? [];
+    const colW = Math.min(160 / Math.max(growth.length, 1), 40);
+    growth.forEach((m, i) => {
+      const x = 20 + i * colW;
+      doc.setFillColor(227, 38, 46);
+      const barH = Math.max((m.value / Math.max(...growth.map(g => g.value), 1)) * 30, 2);
+      doc.rect(x, y + 28 - barH, colW - 4, barH, 'F');
+      doc.setFontSize(7);
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor(100, 100, 100);
+      doc.text(String(m.value), x + colW / 2 - 3, y + 32);
+      doc.setFontSize(6);
+      doc.text(m.label.substring(0, 8), x + colW / 2 - 6, y + 38);
+    });
+
+    y += 50;
+
+    // Carreras
+    doc.setFontSize(14);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(26, 26, 26);
+    doc.text('Distribucion por Carrera', 20, y);
+    y += 8;
+
+    doc.setFillColor(240, 240, 240);
+    doc.rect(20, y, 160, 6, 'F');
+    doc.setFontSize(8);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(26, 26, 26);
+    doc.text('Carrera', 22, y + 4.5);
+    doc.text('Cantidad', 140, y + 4.5);
+    doc.text('%', 175, y + 4.5);
+    y += 8;
+
+    const careers = s?.careerDistribution ?? [];
+    const total = careers.reduce((sum, c) => sum + c.count, 0);
+    careers.forEach((c, i) => {
+      if (i % 2 === 0) {
+        doc.setFillColor(248, 248, 248);
+        doc.rect(20, y - 3, 160, 7, 'F');
+      }
+      doc.setFontSize(8);
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor(60, 60, 60);
+      doc.text(c.category, 22, y + 1.5);
+      doc.text(String(c.count), 142, y + 1.5);
+      doc.text(total > 0 ? ((c.count / total) * 100).toFixed(1) + '%' : '0%', 175, y + 1.5);
+      y += 7;
+    });
+
+    // Footer
+    doc.setFontSize(7);
+    doc.setTextColor(180, 180, 180);
+    doc.text('NEXORA Hub - Panel de Administracion', 20, 285);
+    doc.text('Pagina 1 de 1', 160, 285);
+
+    doc.save('nexora-report.pdf');
+  }
 
   // Chart Data as Computed Signals
   readonly lineChartData = computed<ChartConfiguration<'line'>['data']>(() => {
@@ -60,25 +249,15 @@ export class DashboardView implements OnInit {
   public lineChartOptions: ChartOptions<'line'> = {
     responsive: true,
     maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false }
-    },
-    scales: {
-      y: { display: false },
-      x: { 
-        grid: { display: false },
-        ticks: { color: '#9aa3b2' }
-      }
-    }
+    plugins: { legend: { display: false } },
+    scales: { y: { display: false }, x: { grid: { display: false }, ticks: { color: '#9aa3b2' } } }
   };
 
   public pieChartOptions: ChartOptions<'doughnut'> = {
     responsive: true,
     maintainAspectRatio: false,
     cutout: '70%',
-    plugins: {
-      legend: { position: 'bottom', labels: { color: '#9aa3b2', padding: 20 } }
-    }
+    plugins: { legend: { position: 'bottom', labels: { color: '#9aa3b2', padding: 20 } } }
   };
 
   ngOnInit(): void {

--- a/src/app/features/management/services/management.service.spec.ts
+++ b/src/app/features/management/services/management.service.spec.ts
@@ -54,16 +54,14 @@ describe('ManagementService', () => {
     expect(service.loading()).toBe(false);
   });
 
-  it('should load users and append them when requested', () => {
+  it('should load users and append them when requested', async () => {
     const initialUsers = [{ id: '1', fullName: 'User 1' }];
     const newUsers = [{ id: '2', fullName: 'User 2' }];
 
-    // Mock initial state
     service.users.set(initialUsers as any);
-
     httpClientSpy.post.mockReturnValue(of({ data: { allUsers: newUsers } }));
 
-    service.loadUsers(10, 0, true);
+    await firstValueFrom(service.loadUsers(10, 0, true));
 
     expect(service.users().length).toBe(2);
     expect(service.users()[1].fullName).toBe('User 2');

--- a/src/app/features/management/services/management.service.ts
+++ b/src/app/features/management/services/management.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
+import { catchError, map, Observable, tap, finalize } from 'rxjs';
 import { GRAPHQL_URL } from '../../../core/tokens/api-endpoints.token';
 import { Post } from '../../../interfaces/feed/post.model';
 import {
@@ -9,6 +9,7 @@ import {
   GET_CATALOGS, CREATE_FACULTY, UPDATE_FACULTY, DELETE_FACULTY, CREATE_COURSE,
   UPDATE_COURSE, DELETE_COURSE, CREATE_INTEREST, UPDATE_INTEREST, DELETE_INTEREST,
   GET_ADMIN_EVENTS, CREATE_EVENT_MUTATION, UPDATE_EVENT_MUTATION, DELETE_EVENT_MUTATION,
+  PROMOTE_USER_MUTATION,
 } from '../graphql/management.queries';
 import {
   AdminStats, UserProfile, Faculty, Course, AcademicInterest, AdminEvent,
@@ -87,21 +88,22 @@ export class ManagementService {
       });
   }
 
-  loadUsers(limit = 20, offset = 0, append = false, search = ''): void {
+  loadUsers(limit = 20, offset = 0, append = false, search = ''): Observable<UserProfile[]> {
     this.loading.set(true);
-    this.http.post<GqlRes<{ allUsers: UserProfile[] }>>(this.graphqlUrl, {
+    return this.http.post<GqlRes<{ allUsers: UserProfile[] }>>(this.graphqlUrl, {
       query: GET_ALL_USERS, variables: { limit, offset, search },
-    }).pipe(map(r => {
-      if (!r.data) throw new Error(r.errors?.[0]?.message || 'Error GQL');
-      return r.data.allUsers;
-    })).subscribe({
-      next: (data) => {
+    }).pipe(
+      map(r => {
+        if (!r.data) throw new Error(r.errors?.[0]?.message || 'Error GQL');
+        return r.data.allUsers;
+      }),
+      tap(data => {
         if (append) this.users.update(c => [...c, ...data]);
         else this.users.set(data);
-        this.loading.set(false);
-      },
-      error: () => { if (!append) this.users.set([]); this.loading.set(false); },
-    });
+      }),
+      catchError(() => { this.users.set([]); return []; }),
+      finalize(() => this.loading.set(false)),
+    );
   }
 
   loadPosts(limit = 10, offset = 0, append = false): void {
@@ -170,5 +172,12 @@ export class ManagementService {
       if (!r.data) throw new Error('Error GQL');
       return r.data.updateProfileAdmin;
     }));
+  }
+
+  promoteUser(userId: string, role: string): Observable<unknown> {
+    return this.http.post(this.graphqlUrl, {
+      query: PROMOTE_USER_MUTATION,
+      variables: { userId, role },
+    });
   }
 }


### PR DESCRIPTION
…ignOut fix

- Add jsPDF for frontend-only PDF report generation from dashboard stats
- Fix promote modal: limit 5 results, spinner while searching, improved empty state
- Fix signOut navigation path: /auth/login -> /login
- Fix user search: username search via ProfileRepository + email fallback
- Fix loadUsers to return Observable (enables external subscription)
- Remove Anuncio quick-action button
- Update management.service.spec.ts for new Observable-based loadUsers