### PR TITLE
fix: revert environment.prod.ts — es placeholder, no se usa en build

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: true,
   apiBaseUrl: '/api',
   graphqlUrl: '/graphql',
-  supabaseUrl: 'https://myjqviwyovaftjspgobt.supabase.co',
-  supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im15anF2aXd5b3ZhZnRqc3Bnb2J0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mjk4MzU3MDUsImV4cCI6MjA0NTQxMTcwNX0.lXUyL3sGvsHXM5gQ2kECZXH3d5Qe2A7RLuBq0XvKN9c',
+  supabaseUrl: '',
+  supabaseAnonKey: '',
 };


### PR DESCRIPTION
El angular.json usa fileReplacements: en produccion reemplaza environment.ts por environment.generated.prod.ts (generado por sync-runtime-config.mjs desde .env o process.env). environment.prod.ts nunca se compila.
Las claves de Supabase van en .env (gitignored) o en Vercel env vars.